### PR TITLE
[FIX] release: add task id trailer

### DIFF
--- a/scripts/commands/release.py
+++ b/scripts/commands/release.py
@@ -74,7 +74,7 @@ def release(config: configparser.ConfigParser):
                 continue
 
             tag = increment_package_version(spreadsheet_path, version)
-            message = commit_message(spreadsheet_release_title(tag), body)
+            message = commit_message(spreadsheet_release_title(tag), body + "\n\nTask: 0")
 
             # commit
             release_branch = f"{tag}-release-{d}-{h}-BI"


### PR DESCRIPTION
Since a few weeks runbot checks every commit message on the o-spreadsheet repo. They must have a 'Task' trailer with a valid task id (an integer)

Release commits created with this script are missing the trailer and the ci check fails.

See https://runbot.odoo.com/runbot/batch/1449779/build/62238527