### PR TITLE
[FIX] build: support new package name

### DIFF
--- a/scripts/commands/build.py
+++ b/scripts/commands/build.py
@@ -12,9 +12,9 @@ from utils import pushd
 def build(config: configparser.ConfigParser):
     spreadsheet_path = config["spreadsheet"]["repo_path"]
     spreadsheet_branch = get_spreadsheet_branch(config)
-    [repo, _, rel_path] = get_version_info(spreadsheet_branch)
+    [repo, _, rel_path, lib_file_name] = get_version_info(spreadsheet_branch)
     with pushd(spreadsheet_path):
         repo_path = config[repo]["repo_path"]
         full_path = os.path.join(repo_path, rel_path)
         run_build(config)
-        copy_build(config, full_path)
+        copy_build(config, lib_file_name, full_path)

--- a/scripts/commands/push.py
+++ b/scripts/commands/push.py
@@ -29,7 +29,8 @@ def push(config: configparser.ConfigParser, local=False, forceBuild=False):
                 print("Exiting the script...")
                 exit(1)
     spreadsheet_branch = get_spreadsheet_branch(config)
-    [repo, version, rel_path] = get_version_info(spreadsheet_branch)
+    [repo, version, rel_path, lib_file_name] = get_version_info(
+        spreadsheet_branch)
     repo_path = config[repo]["repo_path"]
 
     full_path = os.path.join(repo_path, rel_path)
@@ -43,11 +44,12 @@ def push(config: configparser.ConfigParser, local=False, forceBuild=False):
             f"The branch {spreadsheet_branch} does not contain any new commits."
         )
 
-    title = forceBuild and odoo_commit_title(rel_path, version) or "wip o-spreadsheet lib update"
+    title = forceBuild and odoo_commit_title(
+        rel_path, version) or "wip o-spreadsheet lib update"
     message = commit_message(title, body)
     checkout(repo_path, spreadsheet_branch)
     run_build(config)
-    copy_build(config, full_path)
+    copy_build(config, lib_file_name, full_path)
     with pushd(repo_path):
         subprocess.check_output(["git", "commit", "-am", message])
         if not local:

--- a/scripts/commands/update.py
+++ b/scripts/commands/update.py
@@ -21,6 +21,7 @@ from helpers import (
 )
 from contributors import CONTRIBUTORS
 
+
 def update(config: configparser.ConfigParser, versions: list[str]):
     print("\n=== UPDATE ODOO ===\nThis may take a while ;-)\n")
     spreadsheet_path = config["spreadsheet"]["repo_path"]
@@ -33,7 +34,7 @@ def update(config: configparser.ConfigParser, versions: list[str]):
     h = str(uuid4())[:4]
 
     for version in versions:
-        [repo, version, rel_path] = spreadsheet_odoo_versions[version]
+        [repo, version, rel_path, lib_file_name] = spreadsheet_odoo_versions[version]
         text = f"Processing version {version}"
         print(text)
         print("=" * len(text))
@@ -94,16 +95,18 @@ def update(config: configparser.ConfigParser, versions: list[str]):
                     f"Branch {version} is up-to-date on odoo/{repo}. Skipping...\n"
                 )
                 continue
-            
+
             # Add contributors
-            body  = body + "\n\n\n" + ("\n").join([ ("Co-authored-by: " + contributor) for contributor in CONTRIBUTORS ])
+            body = body + "\n\n\n" + \
+                ("\n").join([("Co-authored-by: " + contributor)
+                             for contributor in CONTRIBUTORS])
 
             commit_title = odoo_commit_title(rel_path, version)
             message = commit_message(commit_title, body)
             checkout(repo_path, o_branch)
             # build & cp build
             run_build(config)
-            copy_build(config, full_path)
+            copy_build(config, lib_file_name, full_path)
             # commit
             subprocess.check_output(["git", "commit", "-am", message])
             cmd = [
@@ -128,7 +131,8 @@ def update(config: configparser.ConfigParser, versions: list[str]):
         print("\nNewly created PRs:")
         print(
             "\n".join([f"\t{version} - <{url}>" for [version, url] in new_prs]))
-        print(f"Runbot builds: <https://runbot.odoo.com/?search=spreadsheet-{d}-{h}-BI>")
+        print(
+            f"Runbot builds: <https://runbot.odoo.com/?search=spreadsheet-{d}-{h}-BI>")
     if not (old_prs or new_prs):
         print("Every versions are up-to-date")
 

--- a/scripts/helpers.py
+++ b/scripts/helpers.py
@@ -197,18 +197,20 @@ def run_build(config: configparser.ConfigParser):
             exit(1)
 
 
-def copy_build(config: configparser.ConfigParser, destination_path: str):
+def copy_build(config: configparser.ConfigParser, lib_file_name: str, destination_path: str):
     with pushd(os.path.join(config["spreadsheet"]["repo_path"], "build")):
         print("Copying build...")
         # find files
-        for file in ["o_spreadsheet.js", "o_spreadsheet.xml"]:
+        for file in [lib_file_name, "o_spreadsheet.xml"]:
             if os.path.isfile(file):
                 shutil.copy(file, destination_path)
+        shutil.move(f"{destination_path}/{lib_file_name}",
+                    f"{destination_path}/o_spreadsheet.js")
 
 
 def make_PR(path, version, **kwargs) -> str:
     stop = kwargs.get("stop", True)
-    #this can only be used with proper clearance
+    # this can only be used with proper clearance
     autoCommit = kwargs.get("auto", False)
     print("making PR", version, path)
     with pushd(path):

--- a/scripts/shared.py
+++ b/scripts/shared.py
@@ -23,13 +23,14 @@ spreadsheet_odoo_versions = {
         "enterprise",
         "15.0",
         "documents_spreadsheet/static/src/js/o_spreadsheet/",
+        "o_spreadsheet.js",
     ],
-    "16.0": ["odoo", "16.0", "addons/spreadsheet/static/src/o_spreadsheet/"],
-    "17.0": ["odoo", "17.0", "addons/spreadsheet/static/src/o_spreadsheet/"],
-    "saas-17.2": ["odoo", "saas-17.2", "addons/spreadsheet/static/src/o_spreadsheet/"],
-    "saas-17.4": ["odoo", "saas-17.4", "addons/spreadsheet/static/src/o_spreadsheet/"],
-    "18.0": ["odoo", "18.0", "addons/spreadsheet/static/src/o_spreadsheet/"],
-    "master": ["odoo", "master", "addons/spreadsheet/static/src/o_spreadsheet/"],
+    "16.0": ["odoo", "16.0", "addons/spreadsheet/static/src/o_spreadsheet/", "o_spreadsheet.js"],
+    "17.0": ["odoo", "17.0", "addons/spreadsheet/static/src/o_spreadsheet/", "o_spreadsheet.js"],
+    "saas-17.2": ["odoo", "saas-17.2", "addons/spreadsheet/static/src/o_spreadsheet/", "o_spreadsheet.js"],
+    "saas-17.4": ["odoo", "saas-17.4", "addons/spreadsheet/static/src/o_spreadsheet/", "o_spreadsheet.js"],
+    "18.0": ["odoo", "18.0", "addons/spreadsheet/static/src/o_spreadsheet/", "o_spreadsheet.js"],
+    "master": ["odoo", "master", "addons/spreadsheet/static/src/o_spreadsheet/", "o_spreadsheet.esm.js"],
 }
 
 REPOS = ["enterprise", "spreadsheet", "odoo"]


### PR DESCRIPTION
Since 18.1, the lib name has been changed from `o_spreadsheet.js` to `o_spreadsheet.esm.js`. This commit adapts the build scripts to this change.