### PR TITLE
[IMP] config: Support custom config path for all commands

### DIFF
--- a/scripts/config.py
+++ b/scripts/config.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import configparser
 import subprocess
 from const import CONFIG_FILE_PATH
@@ -13,18 +14,21 @@ from shutil import which
 CONFIG_KEYS = ["enterprise", "spreadsheet", "odoo"]
 
 
-def get_config() -> configparser.ConfigParser:
-    if os.path.isfile(CONFIG_FILE_PATH):
+def get_config(path: str) -> configparser.ConfigParser:
+    path = path or CONFIG_FILE_PATH
+    if os.path.isfile(path):
         config = configparser.ConfigParser()
-        config.read(CONFIG_FILE_PATH)
+        config.read(path)
 
         if not all([key in config for key in CONFIG_KEYS]):
             raise Exception(
-                f"Your config file is corrupted. Please fix it or delete it.\nPath: {CONFIG_FILE_PATH}"
+                f"Your config file is corrupted. Please fix it or delete it.\nPath: {path}"
             )
         return config
-    else:
+    elif path == CONFIG_FILE_PATH:
         return create_config()
+    else:
+        sys.exit(f"Config file not found at path: {path}")
 
 
 def check_gh():

--- a/scripts/sp_tool.py
+++ b/scripts/sp_tool.py
@@ -16,9 +16,9 @@ from config import get_config
 pp = pprint.PrettyPrinter(depth=30)
 
 
-def loader() -> dict:
+def loader(path) -> dict:
     check_versions()
-    return {"config": get_config()}
+    return {"config": get_config(path)}
 
 
 def main():
@@ -27,21 +27,22 @@ def main():
     =================
 
     Usage:
-        sp_tool release [-s] [-t | -e] [TARGET...]
-        sp_tool update [-s] [-t | -e] [TARGET...]
-        sp_tool build [-s]
-        sp_tool push [-l -f -s]
-        sp_tool list-pr
-        sp_tool process
+        sp_tool release [-s] [-t | -e] [TARGET...] [--config <path>]
+        sp_tool update [-s] [-t | -e] [TARGET...] [--config <path>]
+        sp_tool build [-s] [--config <path>]
+        sp_tool push [-l -f -s] [--config <path>]
+        sp_tool list-pr [--config <path>]
+        sp_tool process [--config <path>]
         sp_tool -h | --help | --version
 
     Options:
-        -h --help   Show this screen
-        --version   Show version
-        -l          commit locally (don't push on remote)
-        -s          silent mode
-        -t          include branches
-        -e          exclude branches
+        -h --help        Show this screen
+        --version        Show version
+        --config <path>  Path to a config file in format .ini [default: ~/.spConfig.ini]
+        -l               commit locally (don't push on remote)
+        -s               silent mode
+        -t               include branches
+        -e               exclude branches
 
 
 
@@ -57,8 +58,11 @@ def main():
 
     """
     arguments = docopt(main.__doc__, version="0.1.1", options_first=False)
+
     # LOADER
-    config = loader()["config"]
+    config_file_path = os.path.expanduser(arguments["--config"])
+    config = loader(config_file_path)["config"]
+
     # pre-process
     if arguments["-t"] and arguments["-e"]:
         sys.exit("Arguments -t and -e are mutually exclusive. Make a choice ;-)")


### PR DESCRIPTION
This commit adds the possibility to use a custom path for the config file on all commands. The path can be expressed with "~/file".