### PR TITLE
[FIX] release: add proper branch prefix

### DIFF
--- a/scripts/commands/release.py
+++ b/scripts/commands/release.py
@@ -76,7 +76,7 @@ def release(config: configparser.ConfigParser, versions: list[str]):
             message = commit_message(spreadsheet_release_title(tag), body + "\n\nTask: 0")
 
             # commit
-            release_branch = f"{tag}-release-{d}-{h}-BI"
+            release_branch = f"{version}-{tag}-release-{d}-{h}-BI"
 
             subprocess.check_output(["git", "checkout", "-b", release_branch])
             subprocess.check_output(["git", "commit", "-am", message])


### PR DESCRIPTION
before:	18.2.17-release-1206-2680-BI
after:	saas-18.2-18.2.17-release-1206-2680-BI

Add the proper branch prefix to release branch to help runbot find the correct target.